### PR TITLE
Move actions to top-right menu

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -120,6 +120,50 @@ header {
     background: color-mix(in oklab, #b91c1c 12%, transparent);
 }
 
+/* Top-right menu */
+.menu { position: relative; }
+
+.menu-dropdown {
+    position: absolute;
+    right: 0;
+    top: 100%;
+    margin-top: 8px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    box-shadow: var(--shadow);
+    display: none;
+    min-width: 160px;
+    padding: 4px 0;
+    z-index: 20;
+}
+
+.menu-dropdown.show { display: block; }
+
+.menu-item {
+    width: 100%;
+    border: none;
+    background: none;
+    color: var(--text);
+    padding: 8px 12px;
+    font-size: 14px;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    cursor: pointer;
+}
+
+.menu-item:hover { background: var(--surface-2); }
+
+.menu-divider {
+    height: 1px;
+    background: var(--border);
+    margin: 4px 0;
+}
+
+.menu-item.danger { color: #b91c1c; }
+.menu-item.danger:hover { background: color-mix(in oklab, #b91c1c 6%, transparent); }
+
 .seg {
     display: inline-flex;
     border: 1px solid var(--border);
@@ -456,9 +500,8 @@ tbody{
   
       /* Header: keep only theme on mobile */
       #btnEdit, #btnReview { display: none; }
-      #btnTheme { padding: 8px; border-radius: 999px; }
-      #btnTheme span { display: none; }
-      #btnTheme .lucide { width: 20px; height: 20px; }
+      #btnMenu { padding: 8px; border-radius: 999px; }
+      #btnMenu .lucide { width: 20px; height: 20px; }
   
       /* Segmented controls full width */
       #review-view .toolbar { display: grid; grid-template-columns: 1fr; gap: 10px; }

--- a/index.html
+++ b/index.html
@@ -50,29 +50,27 @@
                             data-lucide="table"></i><span>Edit</span></button>
                     <button class="btn" id="btnReview" title="Review (R)"><i
                             data-lucide="play"></i><span>Review</span></button>
-                    <button class="btn" id="btnTheme" title="Toggle light/dark"><i
-                            data-lucide="moon"></i><span>Dark</span></button>
+                    <div class="menu" id="menuWrap">
+                        <button class="btn" id="btnMenu" title="Menu"><i data-lucide="ellipsis-vertical"></i></button>
+                        <div class="menu-dropdown" id="menu">
+                            <button class="menu-item" id="btnTheme"><i data-lucide="moon"></i><span>Dark Mode</span></button>
+                            <div class="menu-divider"></div>
+                            <button class="menu-item" id="btnExport"><i data-lucide="arrow-up-to-line"></i><span>Export</span></button>
+                            <button class="menu-item" id="btnImport"><i data-lucide="arrow-down-to-line"></i><span>Import</span></button>
+                            <div class="menu-divider"></div>
+                            <button class="menu-item danger" id="btnClear"><i data-lucide="trash-2"></i><span>Delete All</span></button>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
     </header>
 
+    <input type="file" id="importFile" accept=".csv,text/csv" />
+
     <main>
         <!-- Edit view -->
         <section id="edit-view">
-            <div class="toolbar">
-                <button class="btn primary" id="btnExport" title="Export CSV"><i
-                        data-lucide="arrow-up-to-line"></i><span>Export</span></button>
-                <label for="importFile">
-                    <button class="btn" id="btnImport" title="Import CSV"><i
-                            data-lucide="arrow-down-to-line"></i><span>Import</span></button>
-                </label>
-                <input type="file" id="importFile" accept=".csv,text/csv" />
-                <div style="flex:1"></div>
-                <button class="btn danger" id="btnClear" title="Clear all cards"><i
-                        data-lucide="trash-2"></i><span>Clear</span></button>
-            </div>
-
             <div class="table-wrap">
                 <table id="card-table" aria-label="Flashcards table editor">
                     <colgroup>

--- a/js/app.js
+++ b/js/app.js
@@ -33,6 +33,8 @@ const btnExport = document.getElementById("btnExport");
 const btnImport = document.getElementById("btnImport");
 const inputImport = document.getElementById("importFile");
 const btnClear = document.getElementById("btnClear");
+const btnMenu = document.getElementById("btnMenu");
+const menu = document.getElementById("menu");
 
 const btnChrono = document.getElementById("btnChrono");
 const btnRandom = document.getElementById("btnRandom");
@@ -53,12 +55,15 @@ renderView();
 // Event wiring
 btnEdit.onclick = () => showEdit();
 btnReview.onclick = () => startReview();
-btnTheme.onclick = () => toggleTheme();
+btnTheme.onclick = () => { toggleTheme(); menu.classList.remove("show"); };
 
-btnExport.onclick = () => exportCSV();
-btnImport.onclick = () => inputImport.click();
+btnExport.onclick = () => { exportCSV(); menu.classList.remove("show"); };
+btnImport.onclick = () => { inputImport.click(); menu.classList.remove("show"); };
 inputImport.onchange = (e) => importCSV(e);
-btnClear.onclick = () => clearAll();
+btnClear.onclick = () => { clearAll(); menu.classList.remove("show"); };
+
+btnMenu.onclick = (e) => { e.stopPropagation(); menu.classList.toggle("show"); };
+document.addEventListener("click", () => menu.classList.remove("show"));
 
 btnChrono.onclick = () => setOrder("chronological");
 btnRandom.onclick = () => setOrder("random");
@@ -285,8 +290,8 @@ function setTheme(mode) {
 function toggleTheme() { setTheme(dark ? "light" : "dark"); }
 function updateThemeButton() {
     btnTheme.innerHTML = dark
-        ? '<i data-lucide="sun"></i><span>Light</span>'
-        : '<i data-lucide="moon"></i><span>Dark</span>';
+        ? '<i data-lucide="sun"></i><span>Light Mode</span>'
+        : '<i data-lucide="moon"></i><span>Dark Mode</span>';
 }
 
 // ---------- CSV ----------
@@ -388,7 +393,4 @@ function mulberry32(a) {
     return function () { let t = a += 0x6D2B79F5; t = Math.imul(t ^ t >>> 15, t | 1); t ^= t + Math.imul(t ^ t >>> 7, t | 61); return ((t ^ t >>> 14) >>> 0) / 4294967296; }
 }
 function refreshIcons() { if (window.lucide && lucide.createIcons) try { lucide.createIcons(); } catch (_) { } }
-
-// Expose for buttons needing file input trigger
-document.getElementById("btnImport").addEventListener("click", () => inputImport.click());
     


### PR DESCRIPTION
## Summary
- Replace header theme button and edit toolbar with a three-dot overflow menu
- Implement Dark Mode, Export, Import, and Delete All actions inside the new menu
- Style and script the dropdown for desktop and mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68992741b27883268f5eb85d8e848d15