### PR TITLE
feat: add undo and redo functionality

### DIFF
--- a/js/shortcuts.js
+++ b/js/shortcuts.js
@@ -12,6 +12,8 @@
         global: [
             { id: 'help', title: 'Open shortcuts menu', combos: [[isMac ? 'Cmd' : 'Ctrl', 'Shift', '/']], track: true },
             { id: 'save', title: 'Save', combos: [[isMac ? 'Cmd' : 'Ctrl', 'S']], track: true },
+            { id: 'undo', title: 'Undo', combos: [[isMac ? 'Cmd' : 'Ctrl', 'Z']], track: false },
+            { id: 'redo', title: 'Redo', combos: [[isMac ? 'Cmd' : 'Ctrl', 'Y'], [isMac ? 'Cmd' : 'Ctrl', 'Shift', 'Z']], track: false },
             { id: 'edit', title: 'Go to Edit view', combos: [['E']], track: true },
             { id: 'review', title: 'Start or restart review', combos: [['R']], track: true },
         ],


### PR DESCRIPTION
## Summary
- add undo/redo history stack for cards and review state
- hook history into editing, importing, clearing, and marking cards learned
- support Ctrl/Cmd+Z and Ctrl+Y/Cmd+Shift+Z shortcuts and expose them in help modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68993076b96483269027378ac07afaf6