### PR TITLE
Improve keyboard shortcut modal and segmented buttons

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -180,6 +180,16 @@ header {
     border-radius: 0;
 }
 
+.seg .btn:first-child {
+    border-top-left-radius: 12px;
+    border-bottom-left-radius: 12px;
+}
+
+.seg .btn:last-child {
+    border-top-right-radius: 12px;
+    border-bottom-right-radius: 12px;
+}
+
 .seg .btn.active {
     background: color-mix(in oklab, var(--muted)12%, transparent);
     color: var(--text);
@@ -367,9 +377,11 @@ tbody tr:last-child td {
     border-radius: 16px;
     max-width: 760px;
     width: min(92vw, 760px);
-    max-height: min(90vh, 840px);
-    overflow: auto;
+    max-height: min(90vh, 600px);
+    overflow: hidden;
     padding: 20px;
+    display: flex;
+    flex-direction: column;
 }
 
 .kb-header {
@@ -385,15 +397,22 @@ tbody tr:last-child td {
     font-size: 18px;
 }
 
+.kb-content {
+    overflow: auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 24px;
+}
+
 .kb-section {
-    margin-top: 14px;
+    margin-top: 0;
 }
 
 .kb-section h4 {
     font-size: 13px;
     color: var(--muted);
     margin-bottom: 8px;
-    margin-top: 32px;
+    margin-top: 0;
 }
 
 /* Figma-like rows */

--- a/index.html
+++ b/index.html
@@ -139,17 +139,19 @@
             <div class="kb-header">
                 <div class="kb-title">Keyboard shortcuts</div>
             </div>
-            <div class="kb-section">
-                <h4>Global</h4>
-                <div class="kb-rows" id="kbGlobal"></div>
-            </div>
-            <div class="kb-section">
-                <h4>Edit view</h4>
-                <div class="kb-rows" id="kbEdit"></div>
-            </div>
-            <div class="kb-section">
-                <h4>Review view</h4>
-                <div class="kb-rows" id="kbReview"></div>
+            <div class="kb-content">
+                <div class="kb-section">
+                    <h4>Global</h4>
+                    <div class="kb-rows" id="kbGlobal"></div>
+                </div>
+                <div class="kb-section">
+                    <h4>Edit view</h4>
+                    <div class="kb-rows" id="kbEdit"></div>
+                </div>
+                <div class="kb-section">
+                    <h4>Review view</h4>
+                    <div class="kb-rows" id="kbReview"></div>
+                </div>
             </div>
         </div>
     </div>

--- a/js/app.js
+++ b/js/app.js
@@ -426,7 +426,7 @@ function onGlobalKey(e) {
 
     if (view === "edit") {
         if (!e.metaKey && !e.ctrlKey) {
-            if (key === "r") { startReview(); e.preventDefault(); return; }
+            if (key === "r") { startReview(); toast("Restarted review"); e.preventDefault(); return; }
             if (key === "e") { showEdit(); e.preventDefault(); return; }
         }
         return;
@@ -444,7 +444,7 @@ function onGlobalKey(e) {
         if (k === "d") { setDirection("def-first"); return; }
         if (k === "l") { e.preventDefault(); markLearned(); return; }
         if (k === "e") { showEdit(); return; }
-        if (k === "r") { startReview(); return; }
+        if (k === "r") { startReview(); toast("Restarted review"); return; }
     }
 }
 


### PR DESCRIPTION
## Summary
- Constrain keyboard shortcut modal height, add inner scroll container, and lay out sections in two columns.
- Show a toast when pressing **R** to restart review.
- Match segmented button inner radii to outer container to keep focus rings intact.

## Testing
- `npm test` *(fails: package.json not found)*
- `npx prettier --check css/styles.css index.html js/app.js` *(warnings: code style issues found in 3 files)*

------
https://chatgpt.com/codex/tasks/task_e_689935b05a9c83268c347201a526f69f