### PR TITLE
Add confirmation dialog before clearing flashcards

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,6 +136,15 @@
 
     <div class="toast" id="toast"></div>
 
+    <!-- Clear all confirmation -->
+    <dialog id="clearDialog">
+        <p>Delete all cards?</p>
+        <div style="display:flex; gap:8px; justify-content:flex-end;">
+            <button class="btn danger" id="confirmDelete">Delete All</button>
+            <button class="btn" id="cancelDelete">Cancel</button>
+        </div>
+    </dialog>
+
     <!-- Shortcuts modal -->
     <div class="kb-backdrop" id="kbBackdrop" aria-hidden="true" role="dialog" aria-modal="true">
         <div class="kb-modal" tabindex="-1" id="kbModal">

--- a/js/app.js
+++ b/js/app.js
@@ -107,6 +107,9 @@ const inputImport = document.getElementById("importFile");
 const btnClear = document.getElementById("btnClear");
 const btnMenu = document.getElementById("btnMenu");
 const menu = document.getElementById("menu");
+const clearDialog = document.getElementById("clearDialog");
+const btnDeleteAll = document.getElementById("confirmDelete");
+const btnCancelDelete = document.getElementById("cancelDelete");
 
 const btnChrono = document.getElementById("btnChrono");
 const btnRandom = document.getElementById("btnRandom");
@@ -132,7 +135,9 @@ btnTheme.onclick = () => { toggleTheme(); menu.classList.remove("show"); };
 btnExport.onclick = () => { exportCSV(); menu.classList.remove("show"); };
 btnImport.onclick = () => { inputImport.click(); menu.classList.remove("show"); };
 inputImport.onchange = (e) => importCSV(e);
-btnClear.onclick = () => { clearAll(); menu.classList.remove("show"); };
+btnClear.onclick = () => { clearDialog.showModal(); menu.classList.remove("show"); };
+btnDeleteAll.onclick = () => { clearAll(); clearDialog.close(); };
+btnCancelDelete.onclick = () => clearDialog.close();
 
 btnMenu.onclick = (e) => { e.stopPropagation(); menu.classList.toggle("show"); };
 document.addEventListener("click", () => menu.classList.remove("show"));
@@ -229,7 +234,6 @@ function appendRow(term, def) {
     tbody.appendChild(tr);
 }
 function clearAll() {
-    if (!confirm('Clear all cards?')) return;
     pushHistory();
     cards = [];
     learned.clear();
@@ -430,6 +434,7 @@ function splitCSVLine(line) {
 
 // ---------- Global shortcuts ----------
 function onGlobalKey(e) {
+    if (clearDialog.open) return;
     const isEditingCell = document.activeElement && document.activeElement.classList && document.activeElement.classList.contains("cell");
     const key = e.key ? e.key.toLowerCase() : "";
     const ctrlOrMeta = e.ctrlKey || e.metaKey;


### PR DESCRIPTION
## Summary
- Replace browser confirm with native `<dialog>` modal for deleting all cards
- Style modal buttons with Delete All as destructive action and Cancel fallback
- Ignore global shortcuts while confirmation dialog is open

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/flashcard-app/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68993ea150dc83268686a744eb56be37