### PR TITLE
Fix table row drag and drop

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -165,8 +165,9 @@ cardEl.onclick = () => flipCard();
 // Delegated table events
 tbody.addEventListener("input", onTableInput);
 tbody.addEventListener("keydown", onTableKeydown);
-tbody.addEventListener("dragover", onDragOver);
-tbody.addEventListener("drop", onDrop);
+
+document.addEventListener("dragover", onDragOver);
+document.addEventListener("drop", onDrop);
 
 // Global keys
 document.addEventListener("keydown", onGlobalKey);
@@ -369,11 +370,20 @@ function onDragStart(e, row) {
 function onDragOver(e) {
     if (!draggedRow) return;
     e.preventDefault();
-    const target = e.target.closest("tr");
-    if (!target || target === draggedRow || target === dropLine) return;
-    const rect = target.getBoundingClientRect();
-    const before = e.clientY < rect.top + rect.height / 2;
-    tbody.insertBefore(dropLine, before ? target : target.nextSibling);
+    const rows = [...tbody.querySelectorAll("tr:not(.dragging):not(.drop-line)")];
+    let target = null;
+    for (const r of rows) {
+        const rect = r.getBoundingClientRect();
+        if (e.clientY < rect.top + rect.height / 2) {
+            target = r;
+            break;
+        }
+    }
+    if (target) {
+        tbody.insertBefore(dropLine, target);
+    } else {
+        tbody.appendChild(dropLine);
+    }
 }
 
 function onDrop(e) {


### PR DESCRIPTION
## Summary
- Allow dragging rows even when drag handles sit outside cells
- Compute drop targets based on mouse Y position and use document-level drag/drop listeners

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68994871c7348326b33ca1018d680bdd